### PR TITLE
macOS/clang patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ binfetch
 ib_strap
 *.o
 *.swp
+build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+OS_UNAME = $(shell uname)
+
 PREFIX = /usr
-CONFIG = /usr/share/binfetch
+ifeq ($(OS_UNAME), Darwin)
+	PREFIX := /usr/local
+endif
 
 SRC = ./src
 DEST = ./build
@@ -66,5 +70,5 @@ install: $(PROGRAM)
 	@mkdir -p ${PREFIX}/bin/
 	@cp $(PROGRAM) ${PREFIX}/bin/
 	@echo " INSTALL *.cfg"
-	@mkdir -p ${CONFIG}/
-	@cp cfg/* $(CONFIG)/
+	@mkdir -p ${PREFIX}/share/binfetch
+	@cp cfg/* $(PREFIX)/share/binfetch

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
-OS_UNAME = $(shell uname)
-
-PREFIX = /usr
-ifeq ($(OS_UNAME), Darwin)
-	PREFIX := /usr/local
-endif
+DESTDIR= /
+PREFIX = /usr/local
 
 SRC = ./src
 DEST = ./build
@@ -13,7 +9,7 @@ CC = gcc
 LD = gcc
 STRIP = strip
 
-CFLAGS = -Os -Wall
+CFLAGS = -Os -Wall -DPREFIX=\"$(PREFIX)\"
 LDFLAGS = -flto
 
 LIBS = -lz
@@ -67,8 +63,8 @@ clean:
 
 install: $(PROGRAM)
 	@echo " INSTALL $(PROGRAM)"
-	@mkdir -p ${PREFIX}/bin/
-	@cp $(PROGRAM) ${PREFIX}/bin/
+	@mkdir -p $(DESTDIR)/${PREFIX}/bin/
+	@cp $(PROGRAM) $(DESTDIR)/${PREFIX}/bin/
 	@echo " INSTALL *.cfg"
-	@mkdir -p ${PREFIX}/share/binfetch
-	@cp cfg/* $(PREFIX)/share/binfetch
+	@mkdir -p $(DESTDIR)/${PREFIX}/share/binfetch
+	@cp cfg/* $(DESTDIR)/$(PREFIX)/share/binfetch

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ bootstrap: build_ib $(PROGRAM)
 build_ib:
 	gcc $(SRC)/ib/ib.c -o ib_strap
 	$(eval IB = ./ib_strap)
+	mkdir -p build
 
 check_ib:
 	@which ib > /dev/null 2>&1; \

--- a/src/args.c.ib
+++ b/src/args.c.ib
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 			case 'c':
 				config = optarg
 				break
-			default:
+			default: //
 	
 	if (optind >= argc)
 		fprintf(stderr, "Expected argument after options\n")

--- a/src/args.c.ib
+++ b/src/args.c.ib
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 			case 'c':
 				config = optarg
 				break
-			default: //
+			default:
 	
 	if (optind >= argc)
 		fprintf(stderr, "Expected argument after options\n")

--- a/src/config.c.ib
+++ b/src/config.c.ib
@@ -29,6 +29,9 @@ int parse_cfg(const char * path)
 			strcpy(path, "/usr/share/binfetch/binfetch.cfg")
 			if ((fp = fopen(path, "r")))
 				break
+			strcpy(path, "/usr/local/share/binfetch/binfetch.cfg")
+			if ((fp = fopen(path, "r")))
+				break
 			printf("failed to open standard config\n")
 			return 1
 		

--- a/src/config.c.ib
+++ b/src/config.c.ib
@@ -5,8 +5,8 @@
 #include "pair.h"
 #include "color.h"
 
-#ifndef CONFIG
-	#define CONFIG "/tmp"
+#ifndef PREFIX
+	#define PREFIX "/tmp"
 
 extern tcolor ascii_cols[128]
 extern tcolor main_cols[128]
@@ -26,10 +26,8 @@ int parse_cfg(const char * path)
 			strcat(path, "/.config/binfetch/binfetch.cfg")
 			if ((fp = fopen(path, "r")))
 				break
-			strcpy(path, "/usr/share/binfetch/binfetch.cfg")
-			if ((fp = fopen(path, "r")))
-				break
-			strcpy(path, "/usr/local/share/binfetch/binfetch.cfg")
+			strcpy(path, PREFIX)
+			strcat(path, "/share/binfetch/binfetch.cfg")
 			if ((fp = fopen(path, "r")))
 				break
 			printf("failed to open standard config\n")

--- a/src/ib/ib.c
+++ b/src/ib/ib.c
@@ -843,13 +843,15 @@ static amode short_arg_parser(const char *arg)
 			
 			case 'V': version();
 			
-			default :
+			default:
+			{
 				char invalid[1];
 				invalid[0] = arg[i];
 				
 				warn("invalid option", invalid, 0);
 				
 				return nothing;
+			}
 		}
 		i++;
 	}
@@ -863,6 +865,7 @@ static amode arg_parser(char *arg, const amode last)
 		switch (last)
 		{
 			case space:
+			{
 				const int sp = atoi(arg);
 				
 				if (!sp || sp > 128) error("invalid amount of spaces", arg, 1, 0);
@@ -870,6 +873,7 @@ static amode arg_parser(char *arg, const amode last)
 				spaces       = sp;
 				
 				return nothing;
+			}
 			case soutput:
 				overwrite_out  = arg;
 				return nothing;

--- a/src/ib/ib.c
+++ b/src/ib/ib.c
@@ -844,14 +844,12 @@ static amode short_arg_parser(const char *arg)
 			case 'V': version();
 			
 			default:
-			{
 				char invalid[1];
 				invalid[0] = arg[i];
 				
 				warn("invalid option", invalid, 0);
 				
 				return nothing;
-			}
 		}
 		i++;
 	}


### PR DESCRIPTION
These are just a couple patches that needed to be implemented in order to successfully build (with `make bootstrap`) binfetch on macOS.